### PR TITLE
create directories from file path before writing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,9 @@ impl<'a> Webpage<'a> {
         }
 
         for (path, data) in self.files.iter() {
-            fs::write(folder_path.join(path), data).unwrap();
+            let file_path = folder_path.join(path);
+            fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+            fs::write(file_path, data).unwrap();
         }
 
         let mut args = new_boxed_html_page_arg(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,10 @@ impl<'a> Webpage<'a> {
 
         for (path, data) in self.files.iter() {
             let file_path = folder_path.join(path);
-            fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+            let file_parent = file_path.parent().unwrap();
+            if !file_parent.exists() {
+                fs::create_dir_all(file_parent).unwrap();
+            }
             fs::write(file_path, data).unwrap();
         }
 


### PR DESCRIPTION
This creates the directories which may be specified as part of the file path string for the `.file()` function, before trying to write to them.