### PR TITLE
Make dialog and dialog_ok modules public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,9 +285,9 @@ where
     }
 }
 
-mod dialog;
+pub mod dialog;
 pub use dialog::*;
-mod dialog_ok;
+pub mod dialog_ok;
 pub use dialog_ok::*;
 pub extern crate ramhorns;
 pub use ramhorns::*;


### PR DESCRIPTION
I'm getting unresolved imports with the following
```rs
use skyline_web::DialogOption;
```


This PR will allow accessing that and other similar members via
```rs
use skyline_web::dialog::DialogOption;
```